### PR TITLE
serialize the flat_map as a classic map

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde_derive = { version = "1.0", optional = true }
 [features]
 std = []
 default = ["std"]
-serde1 = ["serde/alloc", "serde_derive"]
+serde1 = ["serde", "serde_derive"]
 
 [dev-dependencies]
 serde_json = { version = "1.0"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flat_map"
-version = "0.0.6"
+version = "0.0.7"
 authors = [
     "Jason Toffaletti <toffaletti@gmail.com>",
     "Michael Dilger <mike@optcomp.nz>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub extern crate alloc;
 
 #[cfg(not(feature = "std"))]
 mod std {
-    pub use core::{ops, hash, fmt, cmp, mem, slice, iter, borrow};
+    pub use core::{ops, hash, fmt, cmp, mem, slice, iter, borrow, marker};
     pub use alloc::*;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,6 @@
 #[cfg(feature = "serde1")]
 extern crate serde;
 
-#[cfg(feature = "serde1")]
-#[macro_use]
-extern crate serde_derive;
-
 #[cfg(not(feature = "std"))]
 #[macro_use]
 pub extern crate alloc;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -537,8 +537,6 @@ fn test_split_off_large_random_sorted() {
     assert!(right.into_iter().eq(data.into_iter().filter(|x| x.0 >= key)));
 }
 
-
-
 #[cfg(feature = "serde")]
 #[test]
 fn test_serde() {


### PR DESCRIPTION
Serialize the FlatMap as a classic Map (example in json):

```json
{ "k1": "v1", "k2": "v2" }
```

instead of

```json
{"v": [["k1", "v1"],["k2", "v2"]]}
```
this way the FlatMap is serialized as a classic map, and not as its
internal representation

Note: I think this is a breaking change so the minor version number should be updated

note2: I also changed the `serde/alloc` feature to just `serde` as `alloc` needs unstable features.
I'm really not sure about this change, did you need alloc for specific reason ?